### PR TITLE
Updated to 1.41

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,8 +1,0 @@
-#upload_channels:
-#  - sfe1ed40
-#channels:
-#  - sfe1ed40
-#channel_targets:
-#  - sfe1ed40
-#build_parameters:
-#  - ""

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -3,8 +3,6 @@ echo "Building %PKG_NAME%."
 set QL_DIR=%LIBRARY_LIB%
 
 cd Python
-%PYTHON% setup.py wrap
-if %ERRORLEVEL% GEQ 1 exit 1
 %PYTHON% setup.py build
 if %ERRORLEVEL% GEQ 1 exit 1
 %PYTHON% setup.py install

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,17 +1,11 @@
 echo "Building %PKG_NAME%."
 
 set QL_DIR=%LIBRARY_LIB%
-REM We do not have versioned libs for boost. mt is not needed since all boost libs are now mt safe. libboost_serialization.lib should be fine.
-REM The only inconvenience is that libboost_serialization-vc141-mt-x64-1_73.lib will be archived into the quantlib-python package. 
-copy "%LIBRARY_LIB%\libboost_serialization.lib" "%LIBRARY_LIB%\libboost_serialization-vc141-mt-x64-1_73.lib"
-if %ERRORLEVEL% GEQ 1 exit 1
 
 cd Python
 %PYTHON% setup.py wrap
 if %ERRORLEVEL% GEQ 1 exit 1
 %PYTHON% setup.py build
-if %ERRORLEVEL% GEQ 1 exit 1
-%PYTHON% setup.py test
 if %ERRORLEVEL% GEQ 1 exit 1
 %PYTHON% setup.py install
 if %ERRORLEVEL% GEQ 1 exit 1

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -5,4 +5,4 @@ echo "Building ${PKG_NAME}."
 ./configure PYTHON CXXFLAGS='-O1'
 make -C Python
 make -C Python wheel
-${PYTHON} -m pip install Python/dist/QuantLib-*.whl --no-deps --ignore-installed --no-build-isolation -vvv
+${PYTHON} -m pip install Python/dist/*.whl --no-deps --ignore-installed --no-build-isolation -vvv

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -4,6 +4,5 @@ echo "Building ${PKG_NAME}."
 ./autogen.sh
 ./configure PYTHON CXXFLAGS='-O1'
 make -C Python
-make -C Python check
 make -C Python wheel
 ${PYTHON} -m pip install Python/dist/QuantLib-*.whl --no-deps --ignore-installed --no-build-isolation -vvv

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,9 +39,11 @@ test:
   imports:
     - QuantLib
   source_files:
-    - Python/test/*
+    - Python/test/
+  requires:
+    - pytest
   commands:
-    - python Python/test/QuantLibTestSuite.py
+    - pytest Python/test/ -v
 
 about:
   home: https://github.com/lballabio/QuantLib

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,13 +1,16 @@
 {% set name = "QuantLib-python" %}
-{% set version = "1.29" %}
+{% set version = "1.41" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://github.com/lballabio/QuantLib-SWIG/archive/refs/tags/QuantLib-SWIG-v{{ version }}.tar.gz
-  sha256: 1671fcd0c49363e38c3a69184b6938fa0df8718489ff6b07503dc056b0e2d10a
+  url: https://github.com/lballabio/QuantLib-SWIG/releases/download/v{{ version }}/QuantLib-SWIG-{{ version }}.tar.gz
+  sha256: fa31023207937616ca0f880eda774b6a2273ba6274e776ee9bf631ddc6bf54b8
+  patches:
+    # Prevent python-build from creating an isolated venv and pulling deps from PyPI.
+    - patches/no-isolation.diff  # [unix]
 
 build:
   number: 0
@@ -26,12 +29,12 @@ requirements:
     - setuptools
     - pip
     - wheel
-    - boost-cpp 1.73.0
+    - python-build  # [unix]
+    - libboost-devel
     - quantlib {{ version }}
   run:
     - python
     - quantlib
-    - boost-cpp >=1.73.0,<2.0a0
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,6 @@ source:
 
 build:
   number: 0
-  skip: true  # [win and vc<14]
 
 requirements:
   build:
@@ -34,7 +33,7 @@ requirements:
     - quantlib {{ version }}
   run:
     - python
-    - quantlib
+    - quantlib  # [not win]
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,7 +31,7 @@ requirements:
     - pip
     - wheel
     - python-build  # [unix]
-    - libboost-devel
+    - libboost-devel {{ libboost }} 
     - quantlib {{ version }}
   run:
     - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,9 @@ build:
 requirements:
   build:
     - {{ compiler('c') }}
-    - {{ compiler('cxx') }}
+- {{ compiler('c') }}
+- {{ compiler('cxx') }}
+- {{ stdlib('c') }}
     - autoconf  # [unix]
     - automake  # [unix]
     - make  # [unix]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,10 +17,8 @@ build:
 
 requirements:
   build:
-    - {{ compiler('c') }}
-- {{ compiler('c') }}
-- {{ compiler('cxx') }}
-- {{ stdlib('c') }}
+    - {{ compiler('cxx') }}
+    - {{ stdlib('c') }}
     - autoconf  # [unix]
     - automake  # [unix]
     - make  # [unix]

--- a/recipe/patches/no-isolation.diff
+++ b/recipe/patches/no-isolation.diff
@@ -1,0 +1,21 @@
+--- Python/Makefile.in	2024-11-11 10:24:23.014415827 -0800
++++ Python/Makefile.in	2024-11-11 10:21:09.902675197 -0800
+@@ -443,7 +443,7 @@
+ @BUILD_PYTHON_TRUE@@HAVE_PYTHON_TRUE@all-local: .build-stamp
+
+ @BUILD_PYTHON_TRUE@@HAVE_PYTHON_TRUE@.build-stamp: src/QuantLib/quantlib_wrap.cpp src/QuantLib/QuantLib.py setup.py
+-@BUILD_PYTHON_TRUE@@HAVE_PYTHON_TRUE@	CXXFLAGS="$(CXXFLAGS) $(CXXWARNINGFLAGS)" CC="$(CC)" CXX="$(CXX)" $(PYTHON) -m build --wheel
++@BUILD_PYTHON_TRUE@@HAVE_PYTHON_TRUE@	CXXFLAGS="$(CXXFLAGS) $(CXXWARNINGFLAGS)" CC="$(CC)" CXX="$(CXX)" $(PYTHON) -m build --wheel --no-isolation
+ @BUILD_PYTHON_TRUE@@HAVE_PYTHON_TRUE@	rm -f LICENSE.TXT
+ @BUILD_PYTHON_TRUE@@HAVE_PYTHON_TRUE@	touch .build-stamp
+
+--- Python/Makefile.am	2024-11-11 10:24:31.128696360 -0800
++++ Python/Makefile.am	2024-11-11 10:21:05.759529034 -0800
+@@ -9,7 +9,7 @@
+ all-local: .build-stamp
+
+ .build-stamp: src/QuantLib/quantlib_wrap.cpp src/QuantLib/QuantLib.py setup.py
+-	CXXFLAGS="$(CXXFLAGS) $(CXXWARNINGFLAGS)" CC="$(CC)" CXX="$(CXX)" $(PYTHON) -m build --wheel
++	CXXFLAGS="$(CXXFLAGS) $(CXXWARNINGFLAGS)" CC="$(CC)" CXX="$(CXX)" $(PYTHON) -m build --wheel --no-isolation
+ 	rm -f LICENSE.TXT
+ 	touch .build-stamp


### PR DESCRIPTION
quantlib-python 1.41

**Destination channel:** defaults

### Links

- [PKG-13460](https://anaconda.atlassian.net/browse/PKG-13460)
- [Upstream repository](https://github.com/lballabio/QuantLib-SWIG)
- [Upstream changelog/diff](https://github.com/lballabio/QuantLib-SWIG/releases/tag/v1.41)
- Relevant dependency PRs:
  - [quantlib 1.41 (PR #5)](https://github.com/AnacondaRecipes/quantlib-feedstock/pull/5) — released

### Explanation of changes:

- Updated from 1.29 to 1.41 (customer request: MUFG, migrate from services to defaults)


[PKG-13460]: https://anaconda.atlassian.net/browse/PKG-13460?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ